### PR TITLE
Add GitHub action workflow to purge webhooks from this repo weekly

### DIFF
--- a/.github/workflows/cron_weekend.yaml
+++ b/.github/workflows/cron_weekend.yaml
@@ -1,0 +1,38 @@
+name: Weekend Cleanup
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * SAT'
+
+jobs:
+  fetchWebhooks:
+    runs-on: ubuntu-latest
+    outputs:
+      hook_ids: ${{ steps.format.outputs.hook_ids }}
+
+    steps:
+      - uses: octokit/request-action@v2.x
+        id: request
+        with:
+          route: GET /repos/hashicorp/test-policy-set/hooks
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - id: format
+        run: |
+          echo "hook_ids=$(jq -n '${{ steps.request.outputs.data }}' | jq -rc '[.[] .id]')\n" >> $GITHUB_OUTPUT
+      - run: |
+          echo 'Deleting these webhook ids: ${{ steps.format.outputs.hook_ids }}'
+  cleanWebhooks:
+    runs-on: ubuntu-latest
+    needs: [ fetchWebhooks ]
+    if: fromJSON(needs.fetchWebhooks.outputs.hook_ids)[0] != null
+    strategy:
+      matrix:
+        value: ${{fromJSON(needs.fetchWebhooks.outputs.hook_ids)}}
+    steps:
+      - uses: octokit/request-action@v2.x
+        id: delete_webhook
+        with:
+          route: DELETE /repos/hashicorp/test-policy-set/hooks/${{ matrix.value }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/cron_weekend.yaml
+++ b/.github/workflows/cron_weekend.yaml
@@ -5,34 +5,8 @@ on:
     - cron: '0 0 * * SAT'
 
 jobs:
-  fetchWebhooks:
-    runs-on: ubuntu-latest
-    outputs:
-      hook_ids: ${{ steps.format.outputs.hook_ids }}
-
+  call-delete-all-webhooks:
     steps:
-      - uses: octokit/request-action@v2.x
-        id: request
-        with:
-          route: GET /repos/hashicorp/test-policy-set/hooks
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-      - id: format
-        run: |
-          echo "hook_ids=$(jq -n '${{ steps.request.outputs.data }}' | jq -rc '[.[] .id]')\n" >> $GITHUB_OUTPUT
-      - run: |
-          echo 'Deleting these webhook ids: ${{ steps.format.outputs.hook_ids }}'
-  cleanWebhooks:
-    runs-on: ubuntu-latest
-    needs: [ fetchWebhooks ]
-    if: fromJSON(needs.fetchWebhooks.outputs.hook_ids)[0] != null
-    strategy:
-      matrix:
-        value: ${{fromJSON(needs.fetchWebhooks.outputs.hook_ids)}}
-    steps:
-      - uses: octokit/request-action@v2.x
-        id: delete_webhook
-        with:
-          route: DELETE /repos/hashicorp/test-policy-set/hooks/${{ matrix.value }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - uses: hashicorp/terraform-random-1/.github/workflows/delete_all_webhooks.yml@main
+        secrets:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
This action is copied from the hashicorp/terraform-random-1 repo, and was written by @brandonc. These repos are used for the same purpose but by different tests, and are vulnerable to the same orphaned webhook problems in cases where tests fail catastrophically enough to prevent cleanup from running.

Since this repo doesn't appear to have any valid persistent webhooks (only temporary ones created by tests running in CI), deleting all hooks weekly seems appropriate.

Co-authored-by: @brandonc